### PR TITLE
Updated gradle to point to any version of Bitmovin newer than 2.16

### DIFF
--- a/comscoreanalytics/build.gradle
+++ b/comscoreanalytics/build.gradle
@@ -38,7 +38,7 @@ dependencies {
     testImplementation 'junit:junit:4.12'
     androidTestImplementation 'com.android.support.test:runner:1.0.2'
     androidTestImplementation 'com.android.support.test.espresso:espresso-core:3.0.2'
-    implementation 'com.bitmovin.player:playercore:2.16.0'
+    implementation 'com.bitmovin.player:playercore:2.16+'
     implementation 'com.comscore:android-analytics:5.+'
     implementation 'com.google.ads.interactivemedia.v3:interactivemedia:3.8.7' // only needed if ads are used
     implementation "com.google.android.gms:play-services-ads:15.0.1" // only needed if ads are used

--- a/comscoreanalyticssample/build.gradle
+++ b/comscoreanalyticssample/build.gradle
@@ -33,7 +33,7 @@ dependencies {
     testImplementation 'junit:junit:4.12'
     androidTestImplementation 'com.android.support.test:runner:1.0.2'
     androidTestImplementation 'com.android.support.test.espresso:espresso-core:3.0.2'
-    implementation 'com.bitmovin.player:playercore:2.16.0'
+    implementation 'com.bitmovin.player:playercore:2.16+'
     implementation 'com.comscore:android-analytics:5.+'
     implementation 'com.google.ads.interactivemedia.v3:interactivemedia:3.8.7' // only needed if ads are used
     implementation "com.google.android.gms:play-services-ads:15.0.1" // only needed if ads are used


### PR DESCRIPTION
Previously we were pinned to version 2.16.0 of the Bitmovin SDK. This updates it to work with any version newer than 2.16.0. This will help our users stay up to date 