### PR TITLE
ComScore CCPA Updates

### DIFF
--- a/comscore/src/main/java/com/bitmovin/player/integration/comscore/ComScoreAnalytics.java
+++ b/comscore/src/main/java/com/bitmovin/player/integration/comscore/ComScoreAnalytics.java
@@ -50,18 +50,22 @@ public class ComScoreAnalytics {
      * Sets the user consent to granted. Use after the ComScoreAnalytics object has been started
      */
     public static synchronized void userConsentGranted() {
-        PublisherConfiguration publisherConfig = Analytics.getConfiguration().getPublisherConfiguration(ComScoreAnalytics.configuration.getPublisherId());
-        publisherConfig.setPersistentLabel("cs_ucfr", ComScoreUserConsent.GRANTED.getValue());
-        Analytics.notifyHiddenEvent();
+        if (started) {
+            PublisherConfiguration publisherConfig = Analytics.getConfiguration().getPublisherConfiguration(ComScoreAnalytics.configuration.getPublisherId());
+            publisherConfig.setPersistentLabel("cs_ucfr", ComScoreUserConsent.GRANTED.getValue());
+            Analytics.notifyHiddenEvent();
+        }
     }
 
     /**
      * Sets the user consent to denied. Use after the ComScoreAnalytics object has been started
      */
     public static synchronized void userConsentDenied() {
-        PublisherConfiguration publisherConfig = Analytics.getConfiguration().getPublisherConfiguration(ComScoreAnalytics.configuration.getPublisherId());
-        publisherConfig.setPersistentLabel("cs_ucfr", ComScoreUserConsent.DENIED.getValue());
-        Analytics.notifyHiddenEvent();
+        if (started) {
+            PublisherConfiguration publisherConfig = Analytics.getConfiguration().getPublisherConfiguration(ComScoreAnalytics.configuration.getPublisherId());
+            publisherConfig.setPersistentLabel("cs_ucfr", ComScoreUserConsent.DENIED.getValue());
+            Analytics.notifyHiddenEvent();
+        }
     }
 
     /**

--- a/comscore/src/main/java/com/bitmovin/player/integration/comscore/ComScoreAnalytics.java
+++ b/comscore/src/main/java/com/bitmovin/player/integration/comscore/ComScoreAnalytics.java
@@ -32,7 +32,7 @@ public class ComScoreAnalytics {
 
             ComScoreUserConsent userConsent = configuration.getUserConsent();
             // Only populate label if user consent is known
-            if (userConsent != ComScoreUserConsent.UNKOWN) {
+            if (userConsent != ComScoreUserConsent.UNKNOWN) {
                 Map<String, String> labels = new HashMap<>();
                 labels.put("cs_ucfr", userConsent.getValue());
                 builder.persistentLabels(labels);

--- a/comscore/src/main/java/com/bitmovin/player/integration/comscore/ComScoreAnalytics.java
+++ b/comscore/src/main/java/com/bitmovin/player/integration/comscore/ComScoreAnalytics.java
@@ -47,13 +47,20 @@ public class ComScoreAnalytics {
     }
 
     /**
-     * Updates the user consent
-     *
-     * @param configuration - The ComScoreConfiguration that contains your application specific information
+     * Sets the user consent to granted. Use after the ComScoreAnalytics object has been started
      */
-    public static synchronized void updateUserConsent(ComScoreConfiguration configuration) {
-        PublisherConfiguration publisherConfig = Analytics.getConfiguration().getPublisherConfiguration(configuration.getPublisherId());
-        publisherConfig.setPersistentLabel("cs_ucfr", configuration.getUserConsent().getValue());
+    public static synchronized void userConsentGranted() {
+        PublisherConfiguration publisherConfig = Analytics.getConfiguration().getPublisherConfiguration(ComScoreAnalytics.configuration.getPublisherId());
+        publisherConfig.setPersistentLabel("cs_ucfr", ComScoreUserConsent.GRANTED.getValue());
+        Analytics.notifyHiddenEvent();
+    }
+
+    /**
+     * Sets the user consent to denied. Use after the ComScoreAnalytics object has been started
+     */
+    public static synchronized void userConsentDenied() {
+        PublisherConfiguration publisherConfig = Analytics.getConfiguration().getPublisherConfiguration(ComScoreAnalytics.configuration.getPublisherId());
+        publisherConfig.setPersistentLabel("cs_ucfr", ComScoreUserConsent.DENIED.getValue());
         Analytics.notifyHiddenEvent();
     }
 

--- a/comscore/src/main/java/com/bitmovin/player/integration/comscore/ComScoreAnalytics.java
+++ b/comscore/src/main/java/com/bitmovin/player/integration/comscore/ComScoreAnalytics.java
@@ -13,6 +13,7 @@ import java.util.Map;
 public class ComScoreAnalytics {
     private static final String TAG = "ComScoreAnalytics";
     private static boolean started;
+    private static ComScoreConfiguration configuration;
 
     /**
      * Starts the ComScoreAnalytics app level tracking
@@ -22,6 +23,8 @@ public class ComScoreAnalytics {
      */
     public static synchronized void start(ComScoreConfiguration configuration, Context context) {
         if (!started) {
+            ComScoreAnalytics.configuration = configuration;
+
             PublisherConfiguration.Builder builder = new PublisherConfiguration.Builder()
                     .publisherId(configuration.getPublisherId())
                     .publisherSecret(configuration.getPublisherSecret())
@@ -52,7 +55,7 @@ public class ComScoreAnalytics {
      */
     public static synchronized ComScoreStreamingAnalytics createComScoreStreamingAnalytics(BitmovinPlayer bitmovinPlayer, ComScoreMetadata metadata) {
         if (started) {
-            return new ComScoreStreamingAnalytics(bitmovinPlayer, metadata);
+            return new ComScoreStreamingAnalytics(bitmovinPlayer, ComScoreAnalytics.configuration, metadata);
         } else {
             Log.e(TAG, "ComScoreStreamingAnalytics was not created. Must call start() first");
             throw new ComScoreAnalyticsException("ComScoreStreamingAnalytics was not created. Must call start() first");

--- a/comscore/src/main/java/com/bitmovin/player/integration/comscore/ComScoreAnalytics.java
+++ b/comscore/src/main/java/com/bitmovin/player/integration/comscore/ComScoreAnalytics.java
@@ -47,6 +47,17 @@ public class ComScoreAnalytics {
     }
 
     /**
+     * Updates the user consent
+     *
+     * @param configuration - The ComScoreConfiguration that contains your application specific information
+     */
+    public static synchronized void updateUserConsent(ComScoreConfiguration configuration) {
+        PublisherConfiguration publisherConfig = Analytics.getConfiguration().getPublisherConfiguration(configuration.getPublisherId());
+        publisherConfig.setPersistentLabel("cs_ucfr", configuration.getUserConsent().getValue());
+        Analytics.notifyHiddenEvent();
+    }
+
+    /**
      * Creates ComScoreStreamingAnalytics object that is attached to your bitmovin player
      *
      * @param bitmovinPlayer - the player to report on

--- a/comscore/src/main/java/com/bitmovin/player/integration/comscore/ComScoreBitmovinAdapter.java
+++ b/comscore/src/main/java/com/bitmovin/player/integration/comscore/ComScoreBitmovinAdapter.java
@@ -60,12 +60,12 @@ public class ComScoreBitmovinAdapter {
         contentType = comScoreContentType(metadata.getMediaType());
     }
 
-    public void giveUserConsent() {
-        updateUserConsent(ComScoreUserConsent.YES);
+    public void userConsentGranted() {
+        updateUserConsent(ComScoreUserConsent.GRANTED);
     }
 
-    public void removeUserConsent() {
-        updateUserConsent(ComScoreUserConsent.NO);
+    public void userConsentDenied() {
+        updateUserConsent(ComScoreUserConsent.DENIED);
     }
 
     private void updateUserConsent(ComScoreUserConsent userConsent) {

--- a/comscore/src/main/java/com/bitmovin/player/integration/comscore/ComScoreBitmovinAdapter.java
+++ b/comscore/src/main/java/com/bitmovin/player/integration/comscore/ComScoreBitmovinAdapter.java
@@ -69,6 +69,7 @@ public class ComScoreBitmovinAdapter {
     }
 
     private void updateUserConsent(ComScoreUserConsent userConsent) {
+        configuration.setUserConsent(userConsent);
         PublisherConfiguration publisherConfig = Analytics.getConfiguration().getPublisherConfiguration(configuration.getPublisherId());
         publisherConfig.setPersistentLabel("cs_ucfr", userConsent.getValue());
         Analytics.notifyHiddenEvent();

--- a/comscore/src/main/java/com/bitmovin/player/integration/comscore/ComScoreBitmovinAdapter.java
+++ b/comscore/src/main/java/com/bitmovin/player/integration/comscore/ComScoreBitmovinAdapter.java
@@ -17,6 +17,8 @@ import com.bitmovin.player.api.event.listener.OnPausedListener;
 import com.bitmovin.player.api.event.listener.OnPlaybackFinishedListener;
 import com.bitmovin.player.api.event.listener.OnPlayingListener;
 import com.bitmovin.player.api.event.listener.OnSourceUnloadedListener;
+import com.comscore.Analytics;
+import com.comscore.PublisherConfiguration;
 import com.comscore.streaming.AdType;
 import com.comscore.streaming.ContentType;
 import com.comscore.streaming.ReducedRequirementsStreamingAnalytics;
@@ -29,6 +31,7 @@ public class ComScoreBitmovinAdapter {
     private static final String ASSET_DURATION_KEY = "ns_st_cl";
 
     private BitmovinPlayer bitmovinPlayer;
+    private ComScoreConfiguration configuration;
     private Map<String, String> metadata;
     private int contentType;
     private ReducedRequirementsStreamingAnalytics streamingAnalytics;
@@ -36,10 +39,11 @@ public class ComScoreBitmovinAdapter {
     private double currentAdDuration;
     private double currentAdOffset;
 
-    public ComScoreBitmovinAdapter(BitmovinPlayer bitmovinPlayer, ComScoreMetadata comScoreMetadata) {
+    public ComScoreBitmovinAdapter(BitmovinPlayer bitmovinPlayer, ComScoreConfiguration comScoreConfiguration, ComScoreMetadata comScoreMetadata) {
         this.bitmovinPlayer = bitmovinPlayer;
-        metadata = comScoreMetadata.toDictionary();
-        contentType = comScoreContentType(comScoreMetadata.getMediaType());
+        this.configuration = comScoreConfiguration;
+        this.metadata = comScoreMetadata.toDictionary();
+        this.contentType = comScoreContentType(comScoreMetadata.getMediaType());
         this.streamingAnalytics = new ReducedRequirementsStreamingAnalytics();
 
         this.bitmovinPlayer.addEventListener(onPlaybackFinishedListener);
@@ -54,6 +58,20 @@ public class ComScoreBitmovinAdapter {
     public void updateMetadata(ComScoreMetadata metadata) {
         this.metadata = metadata.toDictionary();
         contentType = comScoreContentType(metadata.getMediaType());
+    }
+
+    public void giveUserConsent() {
+        updateUserConsent(ComScoreUserConsent.YES);
+    }
+
+    public void removeUserConsent() {
+        updateUserConsent(ComScoreUserConsent.NO);
+    }
+
+    private void updateUserConsent(ComScoreUserConsent userConsent) {
+        PublisherConfiguration publisherConfig = Analytics.getConfiguration().getPublisherConfiguration(configuration.getPublisherId());
+        publisherConfig.setPersistentLabel("cs_ucfr", userConsent.getValue());
+        Analytics.notifyHiddenEvent();
     }
 
     private OnPlaybackFinishedListener onPlaybackFinishedListener = new OnPlaybackFinishedListener() {
@@ -77,7 +95,7 @@ public class ComScoreBitmovinAdapter {
     private OnPausedListener onPausedListener = new OnPausedListener() {
         @Override
         public void onPaused(PausedEvent pausedEvent) {
-            if (!bitmovinPlayer.isAd()){
+            if (!bitmovinPlayer.isAd()) {
                 stop();
             }
         }

--- a/comscore/src/main/java/com/bitmovin/player/integration/comscore/ComScoreConfiguration.java
+++ b/comscore/src/main/java/com/bitmovin/player/integration/comscore/ComScoreConfiguration.java
@@ -32,4 +32,8 @@ public class ComScoreConfiguration {
     public ComScoreUserConsent getUserConsent() {
         return userConsent;
     }
+
+    public void setUserConsent(ComScoreUserConsent userConsent) {
+        this.userConsent = userConsent;
+    }
 }

--- a/comscore/src/main/java/com/bitmovin/player/integration/comscore/ComScoreConfiguration.java
+++ b/comscore/src/main/java/com/bitmovin/player/integration/comscore/ComScoreConfiguration.java
@@ -4,7 +4,7 @@ public class ComScoreConfiguration {
     private String publisherId;
     private String publisherSecret;
     private String applicationName;
-    private ComScoreUserConsent userConsent = ComScoreUserConsent.UNKOWN;
+    private ComScoreUserConsent userConsent = ComScoreUserConsent.UNKNOWN;
 
     public ComScoreConfiguration(String publisherId, String publisherSecret, String applicationName, ComScoreUserConsent userConsent) {
         this(publisherId, publisherSecret, applicationName);

--- a/comscore/src/main/java/com/bitmovin/player/integration/comscore/ComScoreConfiguration.java
+++ b/comscore/src/main/java/com/bitmovin/player/integration/comscore/ComScoreConfiguration.java
@@ -4,6 +4,12 @@ public class ComScoreConfiguration {
     private String publisherId;
     private String publisherSecret;
     private String applicationName;
+    private ComScoreUserConsent userConsent = ComScoreUserConsent.UNKOWN;
+
+    public ComScoreConfiguration(String publisherId, String publisherSecret, String applicationName, ComScoreUserConsent userConsent) {
+        this(publisherId, publisherSecret, applicationName);
+        this.userConsent = userConsent;
+    }
 
     public ComScoreConfiguration(String publisherId, String publisherSecret, String applicationName) {
         this.publisherId = publisherId;
@@ -23,4 +29,7 @@ public class ComScoreConfiguration {
         return applicationName;
     }
 
+    public ComScoreUserConsent getUserConsent() {
+        return userConsent;
+    }
 }

--- a/comscore/src/main/java/com/bitmovin/player/integration/comscore/ComScoreStreamingAnalytics.java
+++ b/comscore/src/main/java/com/bitmovin/player/integration/comscore/ComScoreStreamingAnalytics.java
@@ -25,11 +25,17 @@ public class ComScoreStreamingAnalytics {
         adapter.updateMetadata(metadata);
     }
 
-    public void giveUserConsent() {
-        adapter.giveUserConsent();
+    /**
+     * Update user consent value to granted
+     */
+    public void setUserConsentGranted() {
+        adapter.userConsentGranted();
     }
 
-    public void removeUserConsent() {
-        adapter.removeUserConsent();
+    /**
+     * Update user consent value to denied
+     */
+    public void setUserConsentDenied() {
+        adapter.userConsentDenied();
     }
 }

--- a/comscore/src/main/java/com/bitmovin/player/integration/comscore/ComScoreStreamingAnalytics.java
+++ b/comscore/src/main/java/com/bitmovin/player/integration/comscore/ComScoreStreamingAnalytics.java
@@ -26,14 +26,14 @@ public class ComScoreStreamingAnalytics {
     }
 
     /**
-     * Update user consent value to granted
+     * Sets the user consent value to granted
      */
     public void userConsentGranted() {
         adapter.userConsentGranted();
     }
 
     /**
-     * Update user consent value to denied
+     * Sets the user consent value to denied
      */
     public void userConsentDenied() {
         adapter.userConsentDenied();

--- a/comscore/src/main/java/com/bitmovin/player/integration/comscore/ComScoreStreamingAnalytics.java
+++ b/comscore/src/main/java/com/bitmovin/player/integration/comscore/ComScoreStreamingAnalytics.java
@@ -9,10 +9,11 @@ public class ComScoreStreamingAnalytics {
      * ComScoreStreaming analytics measures video playback and reports back to ComScore.
      *
      * @param bitmovinPlayer - the video player you want to track
+     * @param configuration  - ComScoreConfiguration associated with the source you are going to load
      * @param metadata       - ComScoreMetadata associated with the source you are going to load
      */
-    ComScoreStreamingAnalytics(BitmovinPlayer bitmovinPlayer, ComScoreMetadata metadata) {
-        adapter = new ComScoreBitmovinAdapter(bitmovinPlayer, metadata);
+    ComScoreStreamingAnalytics(BitmovinPlayer bitmovinPlayer, ComScoreConfiguration configuration, ComScoreMetadata metadata) {
+        adapter = new ComScoreBitmovinAdapter(bitmovinPlayer, configuration, metadata);
     }
 
     /**
@@ -22,5 +23,13 @@ public class ComScoreStreamingAnalytics {
      */
     public void updateMetadata(ComScoreMetadata metadata) {
         adapter.updateMetadata(metadata);
+    }
+
+    public void giveUserConsent() {
+        adapter.giveUserConsent();
+    }
+
+    public void removeUserConsent() {
+        adapter.removeUserConsent();
     }
 }

--- a/comscore/src/main/java/com/bitmovin/player/integration/comscore/ComScoreStreamingAnalytics.java
+++ b/comscore/src/main/java/com/bitmovin/player/integration/comscore/ComScoreStreamingAnalytics.java
@@ -28,14 +28,14 @@ public class ComScoreStreamingAnalytics {
     /**
      * Update user consent value to granted
      */
-    public void setUserConsentGranted() {
+    public void userConsentGranted() {
         adapter.userConsentGranted();
     }
 
     /**
      * Update user consent value to denied
      */
-    public void setUserConsentDenied() {
+    public void userConsentDenied() {
         adapter.userConsentDenied();
     }
 }

--- a/comscore/src/main/java/com/bitmovin/player/integration/comscore/ComScoreUserConsent.java
+++ b/comscore/src/main/java/com/bitmovin/player/integration/comscore/ComScoreUserConsent.java
@@ -1,9 +1,9 @@
 package com.bitmovin.player.integration.comscore;
 
 public enum ComScoreUserConsent {
-    NO("0"),
-    YES("1"),
-    UNKOWN("-1");
+    DENIED("0"),
+    GRANTED("1"),
+    UNKNOWN("-1");
 
     private String value;
 

--- a/comscore/src/main/java/com/bitmovin/player/integration/comscore/ComScoreUserConsent.java
+++ b/comscore/src/main/java/com/bitmovin/player/integration/comscore/ComScoreUserConsent.java
@@ -1,0 +1,17 @@
+package com.bitmovin.player.integration.comscore;
+
+public enum ComScoreUserConsent {
+    NO("0"),
+    YES("1"),
+    UNKOWN("-1");
+
+    private String value;
+
+    ComScoreUserConsent(String value) {
+        this.value = value;
+    }
+
+    public String getValue() {
+        return value;
+    }
+}

--- a/comscoresample/build.gradle
+++ b/comscoresample/build.gradle
@@ -9,6 +9,7 @@ android {
         versionCode 1
         versionName "1.0"
         testInstrumentationRunner "android.support.test.runner.AndroidJUnitRunner"
+        multiDexEnabled true
     }
     buildTypes {
         release {

--- a/comscoresample/src/main/AndroidManifest.xml
+++ b/comscoresample/src/main/AndroidManifest.xml
@@ -22,5 +22,8 @@
         <meta-data
             android:name="BITMOVIN_PLAYER_LICENSE_KEY"
             android:value="YOUR_LICENSE_KEY" />
+        <meta-data
+            android:name="com.google.android.gms.ads.AD_MANAGER_APP"
+            android:value="true"/>
     </application>
 </manifest>

--- a/comscoresample/src/main/java/com/bitmovin/player/integration/ComScoreExample/MainActivity.java
+++ b/comscoresample/src/main/java/com/bitmovin/player/integration/ComScoreExample/MainActivity.java
@@ -24,6 +24,7 @@ import com.bitmovin.player.integration.comscore.ComScoreConfiguration;
 import com.bitmovin.player.integration.comscore.ComScoreMediaType;
 import com.bitmovin.player.integration.comscore.ComScoreMetadata;
 import com.bitmovin.player.integration.comscore.ComScoreStreamingAnalytics;
+import com.bitmovin.player.integration.comscore.ComScoreUserConsent;
 
 public class MainActivity extends AppCompatActivity implements View.OnClickListener, KeyEvent.Callback {
     // These are IMA Sample Tags from https://developers.google.com/interactive-media-ads/docs/sdks/android/tags
@@ -48,7 +49,7 @@ public class MainActivity extends AppCompatActivity implements View.OnClickListe
         bitmovinPlayerView = findViewById(R.id.bitmovinPlayerView);
         vodButton.setOnClickListener(this);
 
-        ComScoreConfiguration comScoreConfiguration = new ComScoreConfiguration("YOUR_PUBLISHER_ID", "YOUR_PUBLISHER_SECRET", "APPLICATION_NAME");
+        ComScoreConfiguration comScoreConfiguration = new ComScoreConfiguration("YOUR_PUBLISHER_ID", "YOUR_PUBLISHER_SECRET", "APPLICATION_NAME", ComScoreUserConsent.YES);
         ComScoreAnalytics.start(comScoreConfiguration, getApplicationContext());
 
         // Create new StyleConfiguration

--- a/comscoresample/src/main/java/com/bitmovin/player/integration/ComScoreExample/MainActivity.java
+++ b/comscoresample/src/main/java/com/bitmovin/player/integration/ComScoreExample/MainActivity.java
@@ -49,7 +49,7 @@ public class MainActivity extends AppCompatActivity implements View.OnClickListe
         bitmovinPlayerView = findViewById(R.id.bitmovinPlayerView);
         vodButton.setOnClickListener(this);
 
-        ComScoreConfiguration comScoreConfiguration = new ComScoreConfiguration("YOUR_PUBLISHER_ID", "YOUR_PUBLISHER_SECRET", "APPLICATION_NAME", ComScoreUserConsent.YES);
+        ComScoreConfiguration comScoreConfiguration = new ComScoreConfiguration("YOUR_PUBLISHER_ID", "YOUR_PUBLISHER_SECRET", "APPLICATION_NAME", ComScoreUserConsent.GRANTED);
         ComScoreAnalytics.start(comScoreConfiguration, getApplicationContext());
 
         // Create new StyleConfiguration


### PR DESCRIPTION
Fixes [tub-lib/issues/429](https://github.com/TurnerOpenPlatform/tub-lib/issues/429#event-2864795748).

User consent is passed to ComScore via the `cs_ucfr` param. This can be achieved in two ways:
1. Via `ComScoreConfiguration` optional constructor param
2. By calling `userConsentGranted()` or `userConsentDenied()` on `ComScoreStreamingAnalytics` object

This PR also enables dex support (method count was exceeded) and adds the ad manager tag to manifest as required.