### PR TITLE
Expose secure transmission flag

### DIFF
--- a/comscore/src/main/java/com/bitmovin/player/integration/comscore/ComScoreAnalytics.java
+++ b/comscore/src/main/java/com/bitmovin/player/integration/comscore/ComScoreAnalytics.java
@@ -28,6 +28,7 @@ public class ComScoreAnalytics {
             PublisherConfiguration.Builder builder = new PublisherConfiguration.Builder()
                     .publisherId(configuration.getPublisherId())
                     .publisherSecret(configuration.getPublisherSecret())
+                    .secureTransmission(configuration.isSecureTransmissionEnabled())
                     .applicationName(configuration.getApplicationName());
 
             ComScoreUserConsent userConsent = configuration.getUserConsent();

--- a/comscore/src/main/java/com/bitmovin/player/integration/comscore/ComScoreConfiguration.java
+++ b/comscore/src/main/java/com/bitmovin/player/integration/comscore/ComScoreConfiguration.java
@@ -5,10 +5,22 @@ public class ComScoreConfiguration {
     private String publisherSecret;
     private String applicationName;
     private ComScoreUserConsent userConsent = ComScoreUserConsent.UNKNOWN;
+    private boolean isSecureTransmissionEnabled;
+
+    public ComScoreConfiguration(String publisherId, String publisherSecret, String applicationName, ComScoreUserConsent userConsent, boolean isSecureTransmissionEnabled) {
+        this(publisherId, publisherSecret, applicationName);
+        this.userConsent = userConsent;
+        this.isSecureTransmissionEnabled = isSecureTransmissionEnabled;
+    }
 
     public ComScoreConfiguration(String publisherId, String publisherSecret, String applicationName, ComScoreUserConsent userConsent) {
         this(publisherId, publisherSecret, applicationName);
         this.userConsent = userConsent;
+    }
+
+    public ComScoreConfiguration(String publisherId, String publisherSecret, String applicationName, boolean isSecureTransmissionEnabled) {
+        this(publisherId, publisherSecret, applicationName);
+        this.isSecureTransmissionEnabled = isSecureTransmissionEnabled;
     }
 
     public ComScoreConfiguration(String publisherId, String publisherSecret, String applicationName) {
@@ -31,6 +43,10 @@ public class ComScoreConfiguration {
 
     public ComScoreUserConsent getUserConsent() {
         return userConsent;
+    }
+
+    public boolean isSecureTransmissionEnabled() {
+        return isSecureTransmissionEnabled;
     }
 
     public void setUserConsent(ComScoreUserConsent userConsent) {


### PR DESCRIPTION
Exposes ComScore secure transmission flag to enable more secure communication over `https`

```Java
PublisherConfiguration.Builder()
    .secureTransmission(configuration.isSecureTransmissionEnabled());
```