### PR TITLE
Add generic persistent label API

### DIFF
--- a/comscore/src/main/java/com/bitmovin/player/integration/comscore/ComScoreAnalytics.kt
+++ b/comscore/src/main/java/com/bitmovin/player/integration/comscore/ComScoreAnalytics.kt
@@ -1,7 +1,6 @@
 package com.bitmovin.player.integration.comscore
 
 import android.content.Context
-import android.util.Log
 
 import com.bitmovin.player.BitmovinPlayer
 import com.comscore.Analytics
@@ -48,7 +47,7 @@ object ComScoreAnalytics {
      * Set user consent to [ComScoreUserConsent.GRANTED]
      *
      */
-    @Deprecated("Deprecated as of release 1.3.0", replaceWith = ReplaceWith("applyPersistentLabels(\"labelName\" to \"labelValue\")"))
+    @Deprecated("Deprecated as of release 1.3.0", replaceWith = ReplaceWith("setPersistentLabel(\"label\" to \"value\")"))
     @Synchronized
     fun userConsentGranted() {
         if (isStarted) {
@@ -63,7 +62,7 @@ object ComScoreAnalytics {
      * Set user consent to [ComScoreUserConsent.DENIED]
      *
      */
-    @Deprecated("Deprecated as of release 1.3.0", replaceWith = ReplaceWith("applyPersistentLabel(\"label\" to \"value\")"))
+    @Deprecated("Deprecated as of release 1.3.0", replaceWith = ReplaceWith("setPersistentLabel(\"label\" to \"value\")"))
     @Synchronized
     fun userConsentDenied() {
         if (isStarted) {
@@ -75,20 +74,20 @@ object ComScoreAnalytics {
     }
 
     /**
-     * Apply ComScore persistent labels
+     * Set persistent labels on the ComScore [PublisherConfiguration]
      *
-     * @param labels - the labels to apply
+     * @param labels - the labels to set
      */
     @Synchronized
-    fun applyPersistentLabels(labels: List<Pair<String, String>>) = labels.forEach { applyPersistentLabel(it) }
+    fun setPersistentLabels(labels: List<Pair<String, String>>) = labels.forEach { setPersistentLabel(it) }
 
     /**
-     * Apply a ComScore persistent label
+     * Set a persistent label on the ComScore [PublisherConfiguration]
      *
      * @param label - the label to apply
      */
     @Synchronized
-    fun applyPersistentLabel(label: Pair<String, String>) {
+    fun setPersistentLabel(label: Pair<String, String>) {
         if (isStarted) {
             val publisherConfig = Analytics.getConfiguration().getPublisherConfiguration(configuration.publisherId)
             publisherConfig.setPersistentLabel(label.first, label.second)

--- a/comscore/src/main/java/com/bitmovin/player/integration/comscore/ComScoreAnalytics.kt
+++ b/comscore/src/main/java/com/bitmovin/player/integration/comscore/ComScoreAnalytics.kt
@@ -84,7 +84,7 @@ object ComScoreAnalytics {
     /**
      * Set a persistent label on the ComScore [PublisherConfiguration]
      *
-     * @param label - the label to apply
+     * @param label - the label to set
      */
     @Synchronized
     fun setPersistentLabel(label: Pair<String, String>) {

--- a/comscore/src/main/java/com/bitmovin/player/integration/comscore/ComScoreAnalytics.kt
+++ b/comscore/src/main/java/com/bitmovin/player/integration/comscore/ComScoreAnalytics.kt
@@ -63,7 +63,7 @@ object ComScoreAnalytics {
      * Set user consent to [ComScoreUserConsent.DENIED]
      *
      */
-    @Deprecated("Deprecated as of release 1.3.0", replaceWith = ReplaceWith("applyPersistentLabels(\"labelName\" to \"labelValue\")"))
+    @Deprecated("Deprecated as of release 1.3.0", replaceWith = ReplaceWith("applyPersistentLabel(\"label\" to \"value\")"))
     @Synchronized
     fun userConsentDenied() {
         if (isStarted) {
@@ -80,12 +80,20 @@ object ComScoreAnalytics {
      * @param labels - the labels to apply
      */
     @Synchronized
-    fun applyPersistentLabel(vararg labels: Pair<String, String>) {
+    fun applyPersistentLabels(labels: List<Pair<String, String>>) = labels.forEach { applyPersistentLabel(it) }
+
+    /**
+     * Apply a ComScore persistent label
+     *
+     * @param label - the label to apply
+     */
+    @Synchronized
+    fun applyPersistentLabel(label: Pair<String, String>) {
         if (isStarted) {
             val publisherConfig = Analytics.getConfiguration().getPublisherConfiguration(configuration.publisherId)
-            labels.forEach { publisherConfig.setPersistentLabel(it.first, it.second) }
+            publisherConfig.setPersistentLabel(label.first, label.second)
             Analytics.notifyHiddenEvent()
-            BitLog.d("ComScore persistent labels applied: ${labels.joinToString { "${it.first}:${it.second}" }}")
+            BitLog.d("ComScore persistent label applied: [${label.first}:${label.second}")
         }
     }
 

--- a/comscore/src/main/java/com/bitmovin/player/integration/comscore/ComScoreAnalytics.kt
+++ b/comscore/src/main/java/com/bitmovin/player/integration/comscore/ComScoreAnalytics.kt
@@ -8,19 +8,15 @@ import com.comscore.Analytics
 import com.comscore.PublisherConfiguration
 
 object ComScoreAnalytics {
-    /**
-     * Returns true if the ComScoreAnalytics object has been started. You must do this prior to creating ComScoreStreamingAnalytics
-     *
-     * @return
-     */
+
     var isStarted: Boolean = false
     private lateinit var configuration: ComScoreConfiguration
 
     /**
-     * Starts the ComScoreAnalytics app level tracking
+     * Start [ComScoreAnalytics] app level tracking
      *
-     * @param configuration - ComScore configuration with your app publisher id, publisher secret, and application name
-     * @param context       - Application Context
+     * @param configuration - [ComScoreConfiguration] with app publisher id, publisher secret, and application name
+     * @param context       - Application context
      */
     @Synchronized
     fun start(configuration: ComScoreConfiguration, context: Context) {
@@ -49,8 +45,10 @@ object ComScoreAnalytics {
     }
 
     /**
-     * Sets the user consent to granted. Use after the ComScoreAnalytics object has been started
+     * Set user consent to [ComScoreUserConsent.GRANTED]
+     *
      */
+    @Deprecated("Deprecated as of release 1.3.0", replaceWith = ReplaceWith("applyPersistentLabels(\"labelName\" to \"labelValue\")"))
     @Synchronized
     fun userConsentGranted() {
         if (isStarted) {
@@ -62,8 +60,10 @@ object ComScoreAnalytics {
     }
 
     /**
-     * Sets the user consent to denied. Use after the ComScoreAnalytics object has been started
+     * Set user consent to [ComScoreUserConsent.DENIED]
+     *
      */
+    @Deprecated("Deprecated as of release 1.3.0", replaceWith = ReplaceWith("applyPersistentLabels(\"labelName\" to \"labelValue\")"))
     @Synchronized
     fun userConsentDenied() {
         if (isStarted) {
@@ -75,11 +75,26 @@ object ComScoreAnalytics {
     }
 
     /**
-     * Creates ComScoreStreamingAnalytics object that is attached to your bitmovin player
+     * Apply ComScore persistent labels
      *
-     * @param bitmovinPlayer - the player to report on
-     * @param metadata       - ComScoreMetadata associated with the current loaded source
-     * @return ComScoreStreamingAnalytics object
+     * @param labels - the labels to apply
+     */
+    @Synchronized
+    fun applyPersistentLabel(vararg labels: Pair<String, String>) {
+        if (isStarted) {
+            val publisherConfig = Analytics.getConfiguration().getPublisherConfiguration(configuration.publisherId)
+            labels.forEach { publisherConfig.setPersistentLabel(it.first, it.second) }
+            Analytics.notifyHiddenEvent()
+            BitLog.d("ComScore persistent labels applied: ${labels.joinToString { "${it.first}:${it.second}" }}")
+        }
+    }
+
+    /**
+     * Create [ComScoreStreamingAnalytics] object
+     *
+     * @param bitmovinPlayer - the [BitmovinPlayer] to report on
+     * @param metadata       - [ComScoreMetadata] associated with the current loaded source
+     * @return [ComScoreStreamingAnalytics] object
      */
     @Synchronized
     fun createComScoreStreamingAnalytics(bitmovinPlayer: BitmovinPlayer, metadata: ComScoreMetadata): ComScoreStreamingAnalytics {

--- a/comscore/src/main/java/com/bitmovin/player/integration/comscore/ComScoreAnalytics.kt
+++ b/comscore/src/main/java/com/bitmovin/player/integration/comscore/ComScoreAnalytics.kt
@@ -79,7 +79,16 @@ object ComScoreAnalytics {
      * @param labels - the labels to set
      */
     @Synchronized
-    fun setPersistentLabels(labels: List<Pair<String, String>>) = labels.forEach { setPersistentLabel(it) }
+    fun setPersistentLabels(labels: Map<String, String>) {
+        if (isStarted) {
+            val publisherConfig = Analytics.getConfiguration().getPublisherConfiguration(configuration.publisherId)
+            labels.forEach {
+                publisherConfig.setPersistentLabel(it.key, it.value)
+            }
+            Analytics.notifyHiddenEvent(labels)
+            BitLog.d("ComScore persistent labels set: ${labels.map { "${it.key}:${it.value}" }}")
+        }
+    }
 
     /**
      * Set a persistent label on the ComScore [PublisherConfiguration]
@@ -92,7 +101,7 @@ object ComScoreAnalytics {
             val publisherConfig = Analytics.getConfiguration().getPublisherConfiguration(configuration.publisherId)
             publisherConfig.setPersistentLabel(label.first, label.second)
             Analytics.notifyHiddenEvent()
-            BitLog.d("ComScore persistent label applied: [${label.first}:${label.second}")
+            BitLog.d("ComScore persistent label set: [${label.first}:${label.second}]")
         }
     }
 

--- a/comscore/src/main/java/com/bitmovin/player/integration/comscore/ComScoreBitmovinAdapter.kt
+++ b/comscore/src/main/java/com/bitmovin/player/integration/comscore/ComScoreBitmovinAdapter.kt
@@ -30,7 +30,7 @@ class ComScoreBitmovinAdapter(private val bitmovinPlayer: BitmovinPlayer, privat
         metadataMap.putAll(newMetadata.toMap())
     }
 
-    @Deprecated("Deprecated as of release 1.3.0", replaceWith = ReplaceWith("applyPersistentLabel(\"label\" to \"value\")"))
+    @Deprecated("Deprecated as of release 1.3.0", replaceWith = ReplaceWith("setPersistentLabel(\"label\" to \"value\")"))
     var userConsent: ComScoreUserConsent by Delegates.observable(configuration.userConsent) { _, _, newUserConsent ->
         configuration.userConsent = newUserConsent
         Analytics.getConfiguration().getPublisherConfiguration(configuration.publisherId).setPersistentLabel("cs_ucfr", newUserConsent.value)
@@ -131,11 +131,11 @@ class ComScoreBitmovinAdapter(private val bitmovinPlayer: BitmovinPlayer, privat
         }
     }
 
-    fun applyPersistentLabel(label: Pair<String, String>) {
+    fun setPersistentLabel(label: Pair<String, String>) {
         val publisherConfig = Analytics.getConfiguration().getPublisherConfiguration(configuration.publisherId)
         publisherConfig.setPersistentLabel(label.first, label.second)
         Analytics.notifyHiddenEvent()
     }
 
-    fun applyPersistentLabels(labels: List<Pair<String, String>>) = labels.forEach { applyPersistentLabel(it) }
+    fun setPersistentLabels(labels: List<Pair<String, String>>) = labels.forEach { setPersistentLabel(it) }
 }

--- a/comscore/src/main/java/com/bitmovin/player/integration/comscore/ComScoreBitmovinAdapter.kt
+++ b/comscore/src/main/java/com/bitmovin/player/integration/comscore/ComScoreBitmovinAdapter.kt
@@ -8,7 +8,7 @@ import com.comscore.streaming.AdType
 import com.comscore.streaming.ReducedRequirementsStreamingAnalytics
 import kotlin.properties.Delegates
 
-class ComScoreBitmovinAdapter(private val bitmovinPlayer: BitmovinPlayer, configuration: ComScoreConfiguration, comScoreMetadata: ComScoreMetadata) {
+class ComScoreBitmovinAdapter(private val bitmovinPlayer: BitmovinPlayer, private val configuration: ComScoreConfiguration, comScoreMetadata: ComScoreMetadata) {
     companion object {
         private const val ASSET_DURATION_KEY = "ns_st_cl"
     }
@@ -29,6 +29,8 @@ class ComScoreBitmovinAdapter(private val bitmovinPlayer: BitmovinPlayer, config
         metadataMap.clear()
         metadataMap.putAll(newMetadata.toMap())
     }
+
+    @Deprecated("Deprecated as of release 1.3.0", replaceWith = ReplaceWith("applyPersistentLabel(\"labelName\" to \"labelValue\")"))
     var userConsent: ComScoreUserConsent by Delegates.observable(configuration.userConsent) { _, _, newUserConsent ->
         configuration.userConsent = newUserConsent
         Analytics.getConfiguration().getPublisherConfiguration(configuration.publisherId).setPersistentLabel("cs_ucfr", newUserConsent.value)
@@ -127,5 +129,11 @@ class ComScoreBitmovinAdapter(private val bitmovinPlayer: BitmovinPlayer, config
             BitLog.d("Starting ComScore ad play tracking")
             streamingAnalytics.playVideoAdvertisement(adMap, adType)
         }
+    }
+
+    fun applyPersistentLabel(vararg labels: Pair<String, String>) {
+        val publisherConfig = Analytics.getConfiguration().getPublisherConfiguration(configuration.publisherId)
+        labels.forEach { publisherConfig.setPersistentLabel(it.first, it.second) }
+        Analytics.notifyHiddenEvent()
     }
 }

--- a/comscore/src/main/java/com/bitmovin/player/integration/comscore/ComScoreBitmovinAdapter.kt
+++ b/comscore/src/main/java/com/bitmovin/player/integration/comscore/ComScoreBitmovinAdapter.kt
@@ -30,7 +30,7 @@ class ComScoreBitmovinAdapter(private val bitmovinPlayer: BitmovinPlayer, privat
         metadataMap.putAll(newMetadata.toMap())
     }
 
-    @Deprecated("Deprecated as of release 1.3.0", replaceWith = ReplaceWith("applyPersistentLabel(\"labelName\" to \"labelValue\")"))
+    @Deprecated("Deprecated as of release 1.3.0", replaceWith = ReplaceWith("applyPersistentLabel(\"label\" to \"value\")"))
     var userConsent: ComScoreUserConsent by Delegates.observable(configuration.userConsent) { _, _, newUserConsent ->
         configuration.userConsent = newUserConsent
         Analytics.getConfiguration().getPublisherConfiguration(configuration.publisherId).setPersistentLabel("cs_ucfr", newUserConsent.value)
@@ -131,9 +131,11 @@ class ComScoreBitmovinAdapter(private val bitmovinPlayer: BitmovinPlayer, privat
         }
     }
 
-    fun applyPersistentLabel(vararg labels: Pair<String, String>) {
+    fun applyPersistentLabel(label: Pair<String, String>) {
         val publisherConfig = Analytics.getConfiguration().getPublisherConfiguration(configuration.publisherId)
-        labels.forEach { publisherConfig.setPersistentLabel(it.first, it.second) }
+        publisherConfig.setPersistentLabel(label.first, label.second)
         Analytics.notifyHiddenEvent()
     }
+
+    fun applyPersistentLabels(labels: List<Pair<String, String>>) = labels.forEach { applyPersistentLabel(it) }
 }

--- a/comscore/src/main/java/com/bitmovin/player/integration/comscore/ComScoreBitmovinAdapter.kt
+++ b/comscore/src/main/java/com/bitmovin/player/integration/comscore/ComScoreBitmovinAdapter.kt
@@ -33,8 +33,7 @@ class ComScoreBitmovinAdapter(private val bitmovinPlayer: BitmovinPlayer, privat
     @Deprecated("Deprecated as of release 1.3.0", replaceWith = ReplaceWith("setPersistentLabel(\"label\" to \"value\")"))
     var userConsent: ComScoreUserConsent by Delegates.observable(configuration.userConsent) { _, _, newUserConsent ->
         configuration.userConsent = newUserConsent
-        Analytics.getConfiguration().getPublisherConfiguration(configuration.publisherId).setPersistentLabel("cs_ucfr", newUserConsent.value)
-        Analytics.notifyHiddenEvent()
+        setPersistentLabel("cs_ucfr" to newUserConsent.value)
     }
 
     init {
@@ -135,7 +134,15 @@ class ComScoreBitmovinAdapter(private val bitmovinPlayer: BitmovinPlayer, privat
         val publisherConfig = Analytics.getConfiguration().getPublisherConfiguration(configuration.publisherId)
         publisherConfig.setPersistentLabel(label.first, label.second)
         Analytics.notifyHiddenEvent()
+        BitLog.d("ComScore persistent label set: [${label.first}:${label.second}]")
     }
 
-    fun setPersistentLabels(labels: List<Pair<String, String>>) = labels.forEach { setPersistentLabel(it) }
+    fun setPersistentLabels(labels: Map<String, String>)  {
+        val publisherConfig = Analytics.getConfiguration().getPublisherConfiguration(configuration.publisherId)
+        labels.forEach {
+            publisherConfig.setPersistentLabel(it.key, it.value)
+        }
+        Analytics.notifyHiddenEvent(labels)
+        BitLog.d("ComScore persistent labels set: ${labels.map { "${it.key}:${it.value}" }}")
+    }
 }

--- a/comscore/src/main/java/com/bitmovin/player/integration/comscore/ComScoreStreamingAnalytics.kt
+++ b/comscore/src/main/java/com/bitmovin/player/integration/comscore/ComScoreStreamingAnalytics.kt
@@ -26,7 +26,7 @@ class ComScoreStreamingAnalytics(bitmovinPlayer: BitmovinPlayer, configuration: 
      * Set user consent to [ComScoreUserConsent.GRANTED]
      *
      */
-    @Deprecated("Deprecated as of release 1.3.0", replaceWith = ReplaceWith("applyPersistentLabels(\"labelName\" to \"labelValue\")"))
+    @Deprecated("Deprecated as of release 1.3.0", replaceWith = ReplaceWith("applyPersistentLabel(\"label\" to \"value\")"))
     fun userConsentGranted() {
         adapter.userConsent = ComScoreUserConsent.GRANTED
     }
@@ -35,15 +35,22 @@ class ComScoreStreamingAnalytics(bitmovinPlayer: BitmovinPlayer, configuration: 
      * Set user consent to [ComScoreUserConsent.DENIED]
      *
      */
-    @Deprecated("Deprecated as of release 1.3.0", replaceWith = ReplaceWith("applyPersistentLabels(\"labelName\" to \"labelValue\")"))
+    @Deprecated("Deprecated as of release 1.3.0", replaceWith = ReplaceWith("applyPersistentLabel(\"label\" to \"value\")"))
     fun userConsentDenied() {
         adapter.userConsent = ComScoreUserConsent.DENIED
     }
 
     /**
-     * Apply ComScore persistent labels
+     * Apply ComScore persistent label
      *
-     * @param labels - the labels to apply
+     * @param label - the label to apply
      */
-    fun applyPersistentLabel(vararg labels: Pair<String, String>) = adapter.applyPersistentLabel(*labels)
+    fun applyPersistentLabel(label: Pair<String, String>) = adapter.applyPersistentLabel(label)
+
+    /**
+     * Apply ComScore persistent label
+     *
+     * @param label - the label to apply
+     */
+    fun applyPersistentLabels(labels: List<Pair<String, String>>) = adapter.applyPersistentLabels(labels)
 }

--- a/comscore/src/main/java/com/bitmovin/player/integration/comscore/ComScoreStreamingAnalytics.kt
+++ b/comscore/src/main/java/com/bitmovin/player/integration/comscore/ComScoreStreamingAnalytics.kt
@@ -5,35 +5,45 @@ import com.bitmovin.player.BitmovinPlayer
 /**
  * ComScoreStreaming analytics measures video playback and reports back to ComScore.
  *
- * @param bitmovinPlayer - the video player you want to track
- * @param configuration  - ComScoreConfiguration associated with the source you are going to load
- * @param metadata       - ComScoreMetadata associated with the source you are going to load
+ * @param bitmovinPlayer - the [BitmovinPlayer] to track
+ * @param configuration  - [ComScoreConfiguration] associated with the source to load
+ * @param metadata       - [ComScoreMetadata] associated with the source to load
  */
 class ComScoreStreamingAnalytics(bitmovinPlayer: BitmovinPlayer, configuration: ComScoreConfiguration, metadata: ComScoreMetadata) {
 
     private val adapter: ComScoreBitmovinAdapter = ComScoreBitmovinAdapter(bitmovinPlayer, configuration, metadata)
 
     /**
-     * Updates the metdata for the source you are tracking. You should use method when changing sources.
-     * Unload the old source, update the metadata, and load your new source
+     * Update metadata for tracked source. This should be called when changing sources.
      *
-     * @param metadata
+     * @param metadata - The new [ComScoreMetadata]
      */
     fun updateMetadata(metadata: ComScoreMetadata) {
         adapter.metadata = metadata
     }
 
     /**
-     * Sets the user consent value to granted
+     * Set user consent to [ComScoreUserConsent.GRANTED]
+     *
      */
+    @Deprecated("Deprecated as of release 1.3.0", replaceWith = ReplaceWith("applyPersistentLabels(\"labelName\" to \"labelValue\")"))
     fun userConsentGranted() {
         adapter.userConsent = ComScoreUserConsent.GRANTED
     }
 
     /**
-     * Sets the user consent value to denied
+     * Set user consent to [ComScoreUserConsent.DENIED]
+     *
      */
+    @Deprecated("Deprecated as of release 1.3.0", replaceWith = ReplaceWith("applyPersistentLabels(\"labelName\" to \"labelValue\")"))
     fun userConsentDenied() {
         adapter.userConsent = ComScoreUserConsent.DENIED
     }
+
+    /**
+     * Apply ComScore persistent labels
+     *
+     * @param labels - the labels to apply
+     */
+    fun applyPersistentLabel(vararg labels: Pair<String, String>) = adapter.applyPersistentLabel(*labels)
 }

--- a/comscore/src/main/java/com/bitmovin/player/integration/comscore/ComScoreStreamingAnalytics.kt
+++ b/comscore/src/main/java/com/bitmovin/player/integration/comscore/ComScoreStreamingAnalytics.kt
@@ -1,6 +1,7 @@
 package com.bitmovin.player.integration.comscore
 
 import com.bitmovin.player.BitmovinPlayer
+import com.comscore.PublisherConfiguration
 
 /**
  * ComScoreStreaming analytics measures video playback and reports back to ComScore.
@@ -41,16 +42,16 @@ class ComScoreStreamingAnalytics(bitmovinPlayer: BitmovinPlayer, configuration: 
     }
 
     /**
-     * Apply ComScore persistent label
+     * Set a persistent label on the ComScore [PublisherConfiguration]
      *
-     * @param label - the label to apply
+     * @param label - the label to set
      */
     fun setPersistentLabel(label: Pair<String, String>) = adapter.setPersistentLabel(label)
 
     /**
-     * Apply ComScore persistent label
+     * Set persistent labels on the ComScore [PublisherConfiguration]
      *
-     * @param label - the label to apply
+     * @param labels - the labels to set
      */
     fun setPersistentLabels(labels: List<Pair<String, String>>) = adapter.setPersistentLabels(labels)
 }

--- a/comscore/src/main/java/com/bitmovin/player/integration/comscore/ComScoreStreamingAnalytics.kt
+++ b/comscore/src/main/java/com/bitmovin/player/integration/comscore/ComScoreStreamingAnalytics.kt
@@ -53,5 +53,5 @@ class ComScoreStreamingAnalytics(bitmovinPlayer: BitmovinPlayer, configuration: 
      *
      * @param labels - the labels to set
      */
-    fun setPersistentLabels(labels: List<Pair<String, String>>) = adapter.setPersistentLabels(labels)
+    fun setPersistentLabels(labels: Map<String, String>) = adapter.setPersistentLabels(labels)
 }

--- a/comscore/src/main/java/com/bitmovin/player/integration/comscore/ComScoreStreamingAnalytics.kt
+++ b/comscore/src/main/java/com/bitmovin/player/integration/comscore/ComScoreStreamingAnalytics.kt
@@ -26,7 +26,7 @@ class ComScoreStreamingAnalytics(bitmovinPlayer: BitmovinPlayer, configuration: 
      * Set user consent to [ComScoreUserConsent.GRANTED]
      *
      */
-    @Deprecated("Deprecated as of release 1.3.0", replaceWith = ReplaceWith("applyPersistentLabel(\"label\" to \"value\")"))
+    @Deprecated("Deprecated as of release 1.3.0", replaceWith = ReplaceWith("setPersistentLabel(\"label\" to \"value\")"))
     fun userConsentGranted() {
         adapter.userConsent = ComScoreUserConsent.GRANTED
     }
@@ -35,7 +35,7 @@ class ComScoreStreamingAnalytics(bitmovinPlayer: BitmovinPlayer, configuration: 
      * Set user consent to [ComScoreUserConsent.DENIED]
      *
      */
-    @Deprecated("Deprecated as of release 1.3.0", replaceWith = ReplaceWith("applyPersistentLabel(\"label\" to \"value\")"))
+    @Deprecated("Deprecated as of release 1.3.0", replaceWith = ReplaceWith("setPersistentLabel(\"label\" to \"value\")"))
     fun userConsentDenied() {
         adapter.userConsent = ComScoreUserConsent.DENIED
     }
@@ -45,12 +45,12 @@ class ComScoreStreamingAnalytics(bitmovinPlayer: BitmovinPlayer, configuration: 
      *
      * @param label - the label to apply
      */
-    fun applyPersistentLabel(label: Pair<String, String>) = adapter.applyPersistentLabel(label)
+    fun setPersistentLabel(label: Pair<String, String>) = adapter.setPersistentLabel(label)
 
     /**
      * Apply ComScore persistent label
      *
      * @param label - the label to apply
      */
-    fun applyPersistentLabels(labels: List<Pair<String, String>>) = adapter.applyPersistentLabels(labels)
+    fun setPersistentLabels(labels: List<Pair<String, String>>) = adapter.setPersistentLabels(labels)
 }


### PR DESCRIPTION
Addresses [MECBM-44](https://jiraprod.turner.com/browse/MECBM-44) 
* Expose `setPersistentLabel` comscore API for more generic use
* Deprecates user consent granted/denied API