### PR TITLE
Migrate to Comscore SDK 6.x

### DIFF
--- a/comscore/build.gradle
+++ b/comscore/build.gradle
@@ -11,7 +11,7 @@ def libraryCode = 6
 android {
     compileSdkVersion 28
     defaultConfig {
-        minSdkVersion 16
+        minSdkVersion 21
         targetSdkVersion 28
         versionCode libraryCode
         versionName libraryVersion

--- a/comscore/src/main/java/com/bitmovin/player/integration/comscore/ComScoreAnalytics.kt
+++ b/comscore/src/main/java/com/bitmovin/player/integration/comscore/ComScoreAnalytics.kt
@@ -24,21 +24,21 @@ object ComScoreAnalytics {
         if (!isStarted) {
             this.configuration = configuration
 
-            val builder = PublisherConfiguration.Builder()
-                .publisherId(configuration.publisherId)
-                .publisherSecret(configuration.publisherSecret)
-                .secureTransmission(configuration.isSecureTransmissionEnabled)
-                .applicationName(configuration.applicationName)
+            val publisherConfig = PublisherConfiguration.Builder().apply {
+                publisherId(configuration.publisherId)
+                secureTransmission(configuration.isSecureTransmissionEnabled)
 
-            with(configuration.userConsent) {
-                if (this != ComScoreUserConsent.UNKNOWN) {
-                    builder.persistentLabels(mapOf("cs_ucfr" to value))
+                // Only set user consent value if not equal to UNKNOWN
+                if (configuration.userConsent != ComScoreUserConsent.UNKNOWN) {
+                    persistentLabels(mapOf("cs_ucfr" to configuration.userConsent.value))
                 }
+
+            }.build()
+
+            with(Analytics.getConfiguration()) {
+                addClient(publisherConfig)
+                setApplicationName(configuration.applicationName)
             }
-
-            val publisherConfig = builder.build()
-
-            Analytics.getConfiguration().addClient(publisherConfig)
             Analytics.start(context)
 
             isStarted = true

--- a/comscore/src/main/java/com/bitmovin/player/integration/comscore/ComScoreAnalytics.kt
+++ b/comscore/src/main/java/com/bitmovin/player/integration/comscore/ComScoreAnalytics.kt
@@ -46,36 +46,6 @@ object ComScoreAnalytics {
     }
 
     /**
-     * Set user consent to [ComScoreUserConsent.GRANTED]
-     *
-     */
-    @Deprecated("Deprecated as of release 1.3.0", replaceWith = ReplaceWith("setPersistentLabel(\"label\", \"value\")"))
-    @Synchronized
-    fun userConsentGranted() {
-        if (isStarted) {
-            val publisherConfig = Analytics.getConfiguration().getPublisherConfiguration(configuration.publisherId)
-            publisherConfig.setPersistentLabel("cs_ucfr", ComScoreUserConsent.GRANTED.value)
-            Analytics.notifyHiddenEvent()
-            BitLog.d("ComScore user consent granted")
-        }
-    }
-
-    /**
-     * Set user consent to [ComScoreUserConsent.DENIED]
-     *
-     */
-    @Deprecated("Deprecated as of release 1.3.0", replaceWith = ReplaceWith("setPersistentLabel(\"label\", \"value\")"))
-    @Synchronized
-    fun userConsentDenied() {
-        if (isStarted) {
-            val publisherConfig = Analytics.getConfiguration().getPublisherConfiguration(configuration.publisherId)
-            publisherConfig.setPersistentLabel("cs_ucfr", ComScoreUserConsent.DENIED.value)
-            Analytics.notifyHiddenEvent()
-            BitLog.d("ComScore user consent denied")
-        }
-    }
-
-    /**
      * Set persistent labels on the ComScore [PublisherConfiguration]
      *
      * @param labels - the labels to set

--- a/comscore/src/main/java/com/bitmovin/player/integration/comscore/ComScoreBitmovinAdapter.kt
+++ b/comscore/src/main/java/com/bitmovin/player/integration/comscore/ComScoreBitmovinAdapter.kt
@@ -5,8 +5,10 @@ import com.bitmovin.player.api.event.listener.*
 import com.bitmovin.player.integration.comscore.util.contentType
 import com.bitmovin.player.integration.comscore.util.notifyHiddenEvent
 import com.bitmovin.player.integration.comscore.util.notifyHiddenEvents
-import com.comscore.streaming.AdType
-import com.comscore.streaming.ReducedRequirementsStreamingAnalytics
+import com.comscore.streaming.AdvertisementMetadata
+import com.comscore.streaming.AdvertisementType
+import com.comscore.streaming.ContentMetadata
+import com.comscore.streaming.StreamingAnalytics
 import kotlin.properties.Delegates
 
 class ComScoreBitmovinAdapter(private val bitmovinPlayer: BitmovinPlayer, private val configuration: ComScoreConfiguration, comScoreMetadata: ComScoreMetadata) {
@@ -21,7 +23,7 @@ class ComScoreBitmovinAdapter(private val bitmovinPlayer: BitmovinPlayer, privat
     }
 
     private var metadataMap = comScoreMetadata.toMap().toMutableMap()
-    private val streamingAnalytics = ReducedRequirementsStreamingAnalytics()
+    private val streamingAnalytics = StreamingAnalytics()
     private var comScoreState = ComScoreState.STOPPED
     private var currentAdDuration = 0.0
     private var currentAdOffset = 0.0
@@ -92,7 +94,7 @@ class ComScoreBitmovinAdapter(private val bitmovinPlayer: BitmovinPlayer, privat
         if (comScoreState != ComScoreState.STOPPED) {
             BitLog.d("Stopping ComScore tracking")
             comScoreState = ComScoreState.STOPPED
-            streamingAnalytics.stop()
+            streamingAnalytics.notifyPause()
         }
     }
 
@@ -108,8 +110,18 @@ class ComScoreBitmovinAdapter(private val bitmovinPlayer: BitmovinPlayer, privat
         if (comScoreState != ComScoreState.VIDEO) {
             stop()
             comScoreState = ComScoreState.VIDEO
+
+            val contentMetadata = ContentMetadata.Builder().apply {
+                mediaType(metadata.mediaType.contentType())
+                customLabels(metadataMap)
+            }.build()
+
+            with(streamingAnalytics) {
+                setMetadata(contentMetadata)
+                notifyPlay()
+            }
+
             BitLog.d("Starting ComScore video content tracking")
-            streamingAnalytics.playVideoContentPart(metadataMap, metadata.mediaType.contentType())
         }
     }
 
@@ -119,15 +131,25 @@ class ComScoreBitmovinAdapter(private val bitmovinPlayer: BitmovinPlayer, privat
             stop()
             comScoreState = ComScoreState.ADVERTISEMENT
             val adType = when {
-                bitmovinPlayer.isLive -> AdType.LINEAR_LIVE
-                offset == 0.0 -> AdType.LINEAR_ON_DEMAND_PRE_ROLL
-                offset + duration == bitmovinPlayer.duration -> AdType.LINEAR_ON_DEMAND_POST_ROLL
-                else -> AdType.LINEAR_ON_DEMAND_MID_ROLL
+                bitmovinPlayer.isLive -> AdvertisementType.LIVE
+                offset == 0.0 -> AdvertisementType.ON_DEMAND_PRE_ROLL
+                offset + duration == bitmovinPlayer.duration -> AdvertisementType.ON_DEMAND_POST_ROLL
+                else -> AdvertisementType.ON_DEMAND_MID_ROLL
             }
             val durationValue = (duration * 1000).toInt().toString()
             val adMap = mapOf(ASSET_DURATION_KEY to durationValue)
+
+            val adMetadata = AdvertisementMetadata.Builder().apply {
+                mediaType(adType)
+                customLabels(adMap)
+            }.build()
+
+            with(streamingAnalytics) {
+                setMetadata(adMetadata)
+                notifyPlay()
+            }
+
             BitLog.d("Starting ComScore ad play tracking")
-            streamingAnalytics.playVideoAdvertisement(adMap, adType)
         }
     }
 

--- a/comscore/src/main/java/com/bitmovin/player/integration/comscore/ComScoreBitmovinAdapter.kt
+++ b/comscore/src/main/java/com/bitmovin/player/integration/comscore/ComScoreBitmovinAdapter.kt
@@ -33,12 +33,6 @@ class ComScoreBitmovinAdapter(private val bitmovinPlayer: BitmovinPlayer, privat
         metadataMap.putAll(newMetadata.toMap())
     }
 
-    @Deprecated("Deprecated as of release 1.3.0", replaceWith = ReplaceWith("setPersistentLabel(\"label\", \"value\")"))
-    var userConsent: ComScoreUserConsent by Delegates.observable(configuration.userConsent) { _, _, newUserConsent ->
-        configuration.userConsent = newUserConsent
-        setPersistentLabel("cs_ucfr", newUserConsent.value)
-    }
-
     init {
         BitLog.isEnabled = configuration.isDebug
         BitLog.d("Version ${BuildConfig.VERSION_NAME}")

--- a/comscore/src/main/java/com/bitmovin/player/integration/comscore/ComScoreConfiguration.kt
+++ b/comscore/src/main/java/com/bitmovin/player/integration/comscore/ComScoreConfiguration.kt
@@ -2,7 +2,6 @@ package com.bitmovin.player.integration.comscore
 
 data class ComScoreConfiguration(
     val publisherId: String,
-    val publisherSecret: String,
     val applicationName: String,
     var userConsent: ComScoreUserConsent = ComScoreUserConsent.UNKNOWN,
     val isSecureTransmissionEnabled: Boolean = false,

--- a/comscore/src/main/java/com/bitmovin/player/integration/comscore/ComScoreStreamingAnalytics.kt
+++ b/comscore/src/main/java/com/bitmovin/player/integration/comscore/ComScoreStreamingAnalytics.kt
@@ -24,24 +24,6 @@ class ComScoreStreamingAnalytics(bitmovinPlayer: BitmovinPlayer, configuration: 
     }
 
     /**
-     * Set user consent to [ComScoreUserConsent.GRANTED]
-     *
-     */
-    @Deprecated("Deprecated as of release 1.3.0", replaceWith = ReplaceWith("setPersistentLabel(\"label\", \"value\")"))
-    fun userConsentGranted() {
-        adapter.userConsent = ComScoreUserConsent.GRANTED
-    }
-
-    /**
-     * Set user consent to [ComScoreUserConsent.DENIED]
-     *
-     */
-    @Deprecated("Deprecated as of release 1.3.0", replaceWith = ReplaceWith("setPersistentLabel(\"label\", \"value\")"))
-    fun userConsentDenied() {
-        adapter.userConsent = ComScoreUserConsent.DENIED
-    }
-
-    /**
      * Set a persistent label on the ComScore [PublisherConfiguration]
      *
      * @param label - the name of the label

--- a/comscoresample/build.gradle
+++ b/comscoresample/build.gradle
@@ -6,7 +6,7 @@ android {
     compileSdkVersion 28
     defaultConfig {
         applicationId "com.bitmovin.player.integration.bitmovincomscoreanalyticsexample"
-        minSdkVersion 16
+        minSdkVersion 21
         targetSdkVersion 28
         versionCode 1
         versionName "1.0"

--- a/comscoresample/src/main/AndroidManifest.xml
+++ b/comscoresample/src/main/AndroidManifest.xml
@@ -22,7 +22,7 @@
 
         <meta-data
             android:name="BITMOVIN_PLAYER_LICENSE_KEY"
-            android:value="b6d6c59f-815a-4a63-a7a1-d2fb1f62cc14" />
+            android:value="YOUR_LICENSE_KEY" />
         <meta-data
             android:name="com.google.android.gms.ads.AD_MANAGER_APP"
             android:value="true" />

--- a/comscoresample/src/main/AndroidManifest.xml
+++ b/comscoresample/src/main/AndroidManifest.xml
@@ -8,6 +8,7 @@
         android:allowBackup="true"
         android:icon="@mipmap/ic_launcher"
         android:label="@string/app_name"
+        android:networkSecurityConfig="@xml/network_security_config"
         android:roundIcon="@mipmap/ic_launcher_round"
         android:supportsRtl="true"
         android:theme="@style/AppTheme">
@@ -21,7 +22,7 @@
 
         <meta-data
             android:name="BITMOVIN_PLAYER_LICENSE_KEY"
-            android:value="YOUR_LICENSE_KEY" />
+            android:value="b6d6c59f-815a-4a63-a7a1-d2fb1f62cc14" />
         <meta-data
             android:name="com.google.android.gms.ads.AD_MANAGER_APP"
             android:value="true" />

--- a/comscoresample/src/main/java/com/bitmovin/player/integration/comscoresample/MainActivity.kt
+++ b/comscoresample/src/main/java/com/bitmovin/player/integration/comscoresample/MainActivity.kt
@@ -47,7 +47,6 @@ class MainActivity : AppCompatActivity() {
     private fun startAppTracking() {
         val comScoreConfiguration = ComScoreConfiguration(
             publisherId = "publisherId",
-            publisherSecret = "publisherSecret",
             applicationName = "applicationName",
             userConsent = ComScoreUserConsent.GRANTED,
             isDebug = true
@@ -90,7 +89,7 @@ class MainActivity : AppCompatActivity() {
 
         // Creating a new PlayerConfiguration
         val playerConfiguration = PlayerConfiguration().apply {
-            playbackConfiguration.isAutoplayEnabled = true
+            playbackConfiguration?.isAutoplayEnabled = true
             advertisingConfiguration = AdvertisingConfiguration(preRoll, midRoll, postRoll)
             sourceConfiguration = sourceConfig
         }

--- a/comscoresample/src/main/res/xml/network_security_config.xml
+++ b/comscoresample/src/main/res/xml/network_security_config.xml
@@ -1,0 +1,8 @@
+<network-security-config>
+    <debug-overrides>
+        <trust-anchors>
+            <!-- Trust user added CAs while debuggable only -->
+            <certificates src="user" />
+        </trust-anchors>
+    </debug-overrides>
+</network-security-config>

--- a/dependencies.gradle
+++ b/dependencies.gradle
@@ -4,7 +4,7 @@ ext {
     playServicesAdsVersion = '17.1.2'
     imaSdkVersion = '3.11.3'
     legacySupportVersion = '1.0.0'
-    bitmovinPlayerVersion = '2.46+'
+    bitmovinPlayerVersion = '2.16+'
     comscoreVersion = '6.3.1'
 
     // Library dependencies

--- a/dependencies.gradle
+++ b/dependencies.gradle
@@ -4,8 +4,8 @@ ext {
     playServicesAdsVersion = '17.1.2'
     imaSdkVersion = '3.11.3'
     legacySupportVersion = '1.0.0'
-    bitmovinPlayerVersion = '2.16+'
-    comscoreVersion = '5.+'
+    bitmovinPlayerVersion = '2.46+'
+    comscoreVersion = '6.3.1'
 
     // Library dependencies
     supportDependencies = [


### PR DESCRIPTION
Note: Comscore SDK 6.x requires a min android SDK of 21, so we have to update the min android SDK from 16 to 21